### PR TITLE
travis.yml: Build libgit2 from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
         packages:
         - oracle-java8-installer
         - git
-        - libgit2-dev
+        - cmake
 
 notifications:
     irc:
@@ -21,3 +21,15 @@ notifications:
         use_notice: true
         on_success: change
         on_failure: always
+
+install:
+    - wget https://github.com/libgit2/libgit2/archive/v0.26.0.tar.gz
+    - tar -xaf v0.26.0.tar.gz
+    - cd libgit2-0.26.0
+    - mkdir build && cd build
+    - cmake ..
+    - cmake --build .
+    - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+    - sudo cmake --build . --target install
+    - cd ../..
+    - ./gradlew build


### PR DESCRIPTION
The libgit2 versions included in the distributions supported by travis
are too old to be used with JNativeMerge.

As a workaround, we build libgit2 from source within the container
before installing JDime.

Signed-off-by: Olaf Lessenich <lessenic@fim.uni-passau.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/se-passau/jdime/11)
<!-- Reviewable:end -->
