### PR TITLE
Dockerfile wrapper

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM openjdk:8-jdk-alpine
+
+# Install OpenJFX
+RUN apk --no-cache add ca-certificates wget && \
+    wget --quiet --output-document=/etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-java-openjfx/releases/download/8.151.12-r0/java-openjfx-8.151.12-r0.apk && \
+    apk add --no-cache java-openjfx-8.151.12-r0.apk shadow
+
+# Install git
+RUN apk update && apk upgrade && \
+    apk add --no-cache git
+
+# Clone JDime
+RUN git clone https://github.com/se-passau/jdime.git
+
+# Move to JDime
+WORKDIR jdime
+RUN ./gradlew installDist
+
+RUN mkdir /wkdir
+WORKDIR /wkdir
+
+
+ENTRYPOINT ["/jdime/build/install/JDime/bin/JDime"]


### PR DESCRIPTION
Hi, 

I created a Dockerfile to install JDime in a docker image and execute it without having to fix Java versions, gradle and JFX references.

I published an example image on the docker hub, under my lab organization (acedesign/jdimew).

It allows one to invoke JDime with docker as the only requirements :

> $ docker run --rm -v \`pwd`:/wkdir acedesign/jdimew -v
> jdime version 0.5.0

By mounting the current directory inside the container, it allows JDime to access to the local files.

Docker images are OCI-compliant, and can be transformed into other container-based runtimes (e.g., singluarity).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/se-passau/jdime/20)
<!-- Reviewable:end -->
